### PR TITLE
feat: add `disabled` prop to copy button

### DIFF
--- a/src/assets/icons/icon-copy-disabled.svg
+++ b/src/assets/icons/icon-copy-disabled.svg
@@ -1,0 +1,3 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M17 8a3 3 0 0 0-3 3v2h-1a3 3 0 0 0-3 3v11a3 3 0 0 0 3 3h8a3 3 0 0 0 3-3v-1h1a3 3 0 0 0 3-3v-8.758a3 3 0 0 0-.903-2.145l-3.315-3.242A3 3 0 0 0 21.685 8H17zm5 18v1a1 1 0 0 1-1 1h-8a1 1 0 0 1-1-1V16a1 1 0 0 1 1-1h1v8a3 3 0 0 0 3 3h5zm-6-12v9a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-8.758a1.002 1.002 0 0 0-.301-.715l-3.315-3.242a1 1 0 0 0-.699-.285H17a1 1 0 0 0-1 1v3z" fill="#B1B6CA"/>
+</svg>

--- a/src/components/Copy/index.tsx
+++ b/src/components/Copy/index.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import iconCopy from "assets/icons/icon-copy.svg";
 import iconCopyHover from "assets/icons/icon-copy-hover.svg";
+import iconCopyDisabled from "assets/icons/icon-copy-disabled.svg";
 import { useCallback, useRef } from "react";
 import Tooltip from "components/Tooltip";
 import { css } from "@emotion/react";
@@ -8,6 +9,7 @@ import { css } from "@emotion/react";
 type CopyProps = React.PropsWithChildren<{
   value?: string;
   size?: React.CSSProperties["width"];
+  disabled?: boolean;
 }>;
 
 const Wrapper = styled.button`
@@ -53,9 +55,14 @@ const CopyIcon = styled.div<Pick<CopyProps, "size">>`
   &:hover {
     background-image: url(${iconCopyHover});
   }
+
+  button:disabled & {
+    background-image: url(${iconCopyDisabled});
+    cursor: default;
+  }
 `;
 
-function Copy({ value, size, children }: CopyProps) {
+function Copy({ value, size, children, disabled }: CopyProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const handleClick = useCallback<React.MouseEventHandler<HTMLButtonElement>>(
     (event) => {
@@ -77,7 +84,7 @@ function Copy({ value, size, children }: CopyProps) {
   );
 
   return (
-    <Wrapper onClick={handleClick} type="button">
+    <Wrapper onClick={handleClick} disabled={disabled || !value} type="button">
       <textarea ref={inputRef} value={value} readOnly />
       {children || (
         <Tooltip
@@ -89,6 +96,7 @@ function Copy({ value, size, children }: CopyProps) {
               instance.hide();
             }, 1000);
           }}
+          disabled={disabled || !value}
         >
           <CopyIcon size={size} />
         </Tooltip>


### PR DESCRIPTION
- added `disabled` prop
- plus, if there is no content to copy, the button will automatically be disabled.