### PR TITLE
fix: ensure case insensitive search on SelectAssetForm

### DIFF
--- a/src/components/SelectAssetForm/index.tsx
+++ b/src/components/SelectAssetForm/index.tsx
@@ -89,7 +89,7 @@ function SelectAssetForm(props: SelectAssetFormProps) {
   } = props;
   const theme = useTheme();
   const [searchKeyword, setSearchKeyword] = useState("");
-  const deferredSearchKeyword = useDeferredValue(searchKeyword);
+  const deferredSearchKeyword = useDeferredValue(searchKeyword.toLowerCase());
   const { getAsset } = useAssets();
   const { bookmarks, toggleBookmark } = useBookmark();
   const network = useNetwork();


### PR DESCRIPTION
This enables case insensitive search on `SelectAssetForm`

### Before

https://github.com/user-attachments/assets/74977e95-2740-49e1-bc5e-040473a35cc3

### After

https://github.com/user-attachments/assets/2df4d3cc-211c-47e8-9b5a-0d534d393eda

