### PR TITLE
fix: deactivate swap on no selectedPair

### DIFF
--- a/src/hooks/modals/useFirstProvideModal.tsx
+++ b/src/hooks/modals/useFirstProvideModal.tsx
@@ -1,23 +1,34 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import FirstProvideModal from "components/Modal/FirstProvideModal";
 import useGlobalElement from "hooks/useGlobalElement";
 import useModal from "hooks/useModal";
 
 const useFirstProvideModal = ({
   addresses,
+  onClickCancel,
 }: {
   addresses: [string, string];
+  onClickCancel?: () => void;
 }) => {
   const modal = useModal();
+
+  const handleClose = useCallback(() => {
+    modal.close();
+
+    if (onClickCancel) {
+      onClickCancel();
+    }
+  }, [modal.close, onClickCancel]);
+
   const element = useMemo(
     () => (
       <FirstProvideModal
         addresses={addresses}
         isOpen={modal.isOpen}
-        onRequestClose={modal.close}
+        onRequestClose={handleClose}
       />
     ),
-    [modal.close, modal.isOpen],
+    [handleClose, modal.isOpen],
   );
   useGlobalElement(element);
   return modal;

--- a/src/pages/Trade/Swap/index.tsx
+++ b/src/pages/Trade/Swap/index.tsx
@@ -1083,6 +1083,7 @@ function SwapPage() {
               simulationResult.isLoading ||
               isFeeLoading ||
               isFeeFailed ||
+              !selectedPair ||
               isPoolEmpty
             }
             css={css`

--- a/src/pages/Trade/Swap/index.tsx
+++ b/src/pages/Trade/Swap/index.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import Typography from "components/Typography";
@@ -168,8 +169,15 @@ function SwapPage() {
   const { asset1Address, asset2Address, asset1Value, asset2Value } =
     form.watch();
 
+  const targetRef = useRef<FormKey>();
   const firstProvideModal = useFirstProvideModal({
     addresses: [asset1Address, asset2Address],
+    onClickCancel: () => {
+      if (targetRef.current) {
+        form.setValue(targetRef.current, "");
+        targetRef.current = undefined;
+      }
+    },
   });
 
   const asset1 = useMemo(
@@ -461,6 +469,7 @@ function SwapPage() {
               formData[oppositeTarget] &&
               !findPair([address, formData[oppositeTarget] || ""])
             ) {
+              targetRef.current = target;
               firstProvideModal.open();
             }
 

--- a/src/pages/Trade/Swap/index.tsx
+++ b/src/pages/Trade/Swap/index.tsx
@@ -170,12 +170,18 @@ function SwapPage() {
     form.watch();
 
   const targetRef = useRef<FormKey>();
+  const targetValueRef = useRef<FormKey>();
   const firstProvideModal = useFirstProvideModal({
     addresses: [asset1Address, asset2Address],
     onClickCancel: () => {
       if (targetRef.current) {
         form.setValue(targetRef.current, "");
         targetRef.current = undefined;
+      }
+
+      if (targetValueRef.current) {
+        form.setValue(targetValueRef.current, "");
+        targetValueRef.current = undefined;
       }
     },
   });
@@ -440,16 +446,6 @@ function SwapPage() {
     }
   }, [form, preselectedAsset2Address, setPreselectedAsset2Address]);
 
-  useEffect(() => {
-    if (!asset1Address) {
-      form.setValue(FormKey.asset1Value, "", { shouldValidate: true });
-    }
-
-    if (!asset2Address) {
-      form.setValue(FormKey.asset2Value, "", { shouldValidate: true });
-    }
-  }, [asset1Address, asset2Address, form]);
-
   return (
     <>
       <SelectAssetDrawer
@@ -474,12 +470,22 @@ function SwapPage() {
 
             form.setValue(target, address);
             if (formData[oppositeTarget] === address) {
+              const oppositeTargetValue = selectAsset1Modal.isOpen
+                ? FormKey.asset2Value
+                : FormKey.asset1Value;
+
               form.setValue(oppositeTarget, "");
+              form.setValue(oppositeTargetValue, "");
             } else if (
               formData[oppositeTarget] &&
               !findPair([address, formData[oppositeTarget] || ""])
             ) {
+              const targetValue = selectAsset1Modal.isOpen
+                ? FormKey.asset1Value
+                : FormKey.asset2Value;
+
               targetRef.current = target;
+              targetValueRef.current = targetValue;
               firstProvideModal.open();
             }
 

--- a/src/pages/Trade/Swap/index.tsx
+++ b/src/pages/Trade/Swap/index.tsx
@@ -440,6 +440,16 @@ function SwapPage() {
     }
   }, [form, preselectedAsset2Address, setPreselectedAsset2Address]);
 
+  useEffect(() => {
+    if (!asset1Address) {
+      form.setValue(FormKey.asset1Value, "", { shouldValidate: true });
+    }
+
+    if (!asset2Address) {
+      form.setValue(FormKey.asset2Value, "", { shouldValidate: true });
+    }
+  }, [asset1Address, asset2Address, form]);
+
   return (
     <>
       <SelectAssetDrawer


### PR DESCRIPTION
## Description
- Disables the swap button when no pair is found.
- Unselects the selected asset when the user cancels creating a new pool.
- Clears the value when an asset is unselected.
    - This also applies when an asset is unselected by selecting an already selected asset.

## Before

https://github.com/user-attachments/assets/57e34775-fd19-4948-a138-4e39307aa286


https://github.com/user-attachments/assets/81346005-402f-423d-b243-2e866365b0cc


## After

https://github.com/user-attachments/assets/75458d09-7b75-48fe-8959-fc263ad78582


https://github.com/user-attachments/assets/5d07c6ca-001d-41e9-86fe-a9333e98f6ee



