### PR TITLE
fix: add margin above Expand on Add liquidity modal

### DIFF
--- a/src/pages/Earn/Pools/Provide/index.tsx
+++ b/src/pages/Earn/Pools/Provide/index.tsx
@@ -442,6 +442,7 @@ function ProvidePage() {
         )}
         <div
           css={css`
+            margin-top: 10px;
             margin-bottom: ${isPoolEmpty ? "10px" : "20px"};
           `}
         >


### PR DESCRIPTION
https://www.notion.so/delight-labs/Add-liquidity-1277d06c9eda80ed847aeac2830c65c3?pvs=4

adds a 10px gap between the second and last box to match the spacing between the first and second boxes.

## Before

<img width="610" alt="image" src="https://github.com/user-attachments/assets/0a4343ff-6674-4d41-8a41-6b87848f77f4">

## After

<img width="587" alt="image" src="https://github.com/user-attachments/assets/3c3c0ec4-3d5f-4875-ae29-8ec668501d84">
