### PR TITLE
fix: update to use custom link

### DIFF
--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -3,7 +3,7 @@ import Hr from "components/Hr";
 import IconButton from "components/IconButton";
 import Typography from "components/Typography";
 import { MOBILE_SCREEN_CLASS } from "constants/layout";
-import { Col, Container, Row, useScreenClass } from "react-grid-system";
+import { Container, useScreenClass } from "react-grid-system";
 
 import iconReload from "assets/icons/icon-reload.svg";
 import iconReloadHover from "assets/icons/icon-reload-hover.svg";

--- a/src/pages/Tokens/TokenDetail/index.tsx
+++ b/src/pages/Tokens/TokenDetail/index.tsx
@@ -17,7 +17,7 @@ import {
   Visible,
   useScreenClass,
 } from "react-grid-system";
-import { Link, Outlet, useNavigate, useParams } from "react-router-dom";
+import { Outlet, useNavigate, useParams } from "react-router-dom";
 
 import iconBookmark from "assets/icons/icon-bookmark-default.svg";
 import iconBookmarkSelected from "assets/icons/icon-bookmark-selected.svg";
@@ -41,6 +41,7 @@ import Chart from "./Chart";
 import TokenSummary from "./TokenSummary";
 import TokenTransactions from "./TokenTransactions";
 import TokenPools from "./TokenPools";
+import Link from "components/Link";
 
 const Wrapper = styled.div`
   width: 100%;


### PR DESCRIPTION

## Background

https://www.notion.so/delight-labs/add-liquidity-wallet-1df7d06c9eda8026bba4e00ede3c5947?pvs=4

## Description

Used a custom link component to prevent wallet disconnection caused by chainName changes.

## Checklist

- [ ] Wallet connection should persist when navigating to "Add Liquidity" after connecting
