### PR TITLE
fix: prevent wallet modal from repeatedly opening by removing depende…

### DIFF
--- a/src/pages/Wallet/index.tsx
+++ b/src/pages/Wallet/index.tsx
@@ -57,7 +57,7 @@ function WalletPage() {
     return () => {
       clearTimeout(timerId);
     };
-  }, [connectWalletModal, walletAddress]);
+  }, [ walletAddress]);
 
   useEffect(() => {
     if (!connectWalletModal.isOpen && !walletAddress && isModalOpened.current) {


### PR DESCRIPTION
## Background

https://www.notion.so/delight-labs/settings-modal-1df7d06c9eda8019a77ff86fc54c0186?pvs=4

## Description

Removed unnecessary dependencies from the useEffect dependency array of the wallet connection modal make hash to undefine repeatedly.

## Checklist

- [ ] Verified normal operation of setting modal open/close logic
