### PR TITLE
fix: center text alignment in no notifications modal

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -380,6 +380,7 @@ function Modal({
             noPadding={noPadding}
             style={{
               paddingTop: 0,
+              height: "100%",
             }}
             wrapperStyle={{
               flex: 1,

--- a/src/layout/Main/NotificationModal.tsx
+++ b/src/layout/Main/NotificationModal.tsx
@@ -126,7 +126,11 @@ function NotificationModal(modalProps: ReactModal.Props) {
             display: flex;
             justify-content: center;
             align-items: center;
-            height: 300px;
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            left: 0;
           `}
         >
           <Typography


### PR DESCRIPTION

## Background

https://www.notion.so/delight-labs/1d97d06c9eda802ab644ce291c7f262c?pvs=4

## Description

Centered the "No data" text in the notifications modal to fix an alignment issue.

## Checklist

- [ ] "No data" text is centered in the notifications modal.
