### PR TITLE
fix: correct isInstalled check for interchain kit exts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-tsc --skipLibCheck --noEmit
-npm run lint-staged
+yarn tsc --skipLibCheck --noEmit
+yarn lint-staged

--- a/src/components/Modal/ConnectWalletModal/index.tsx
+++ b/src/components/Modal/ConnectWalletModal/index.tsx
@@ -110,7 +110,9 @@ function ConnectWalletModal(props: ReactModal.Props) {
           !UNSUPPORT_WALLET_LIST[chainName].includes(wallet.info.name),
       )
       .map((wallet: BaseWallet) => {
-        const isInstalled = wallet.walletState !== WalletState.NotExist;
+        const isInstalled = !!(
+          wallet.info.windowKey && wallet.info.windowKey in window
+        );
 
         const iconSrc =
           typeof wallet.info.logo === "string"


### PR DESCRIPTION
<!-- Optional  -->

## Background

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://www.notion.so/delight-labs/Keplr-1ec7d06c9eda80d9b127fa9573cc4b01?pvs=4

## Description

<!--- Describe your changes in detail -->
<!--- Add subsections (e.g. Screenshot, Note) if needed -->

`wallet.walletStatus` is `undefined` before init call whether it is installed.
so the current check doesn't work as expected.

while initializing, ExtensionWallet from interchain-kit checks window has extension object - applies same manner.

### Before

left: installed -> installed [O]
right: not installed -> installed [X]

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/89c762bf-c44c-4cea-a4b5-5000df8a77cb" />

### After

left: installed -> installed [O]
right: not installed -> not installed [O]

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/d1cdc345-2d06-4378-8e34-c76276085dc2" />




## Checklist

- [x] it reflects installation status correctly
