### PR TITLE
fix: use getChainWalletState for check NotExist

### DIFF
--- a/src/components/Modal/ConnectWalletModal/index.tsx
+++ b/src/components/Modal/ConnectWalletModal/index.tsx
@@ -110,10 +110,9 @@ function ConnectWalletModal(props: ReactModal.Props) {
           !UNSUPPORT_WALLET_LIST[chainName].includes(wallet.info.name),
       )
       .map((wallet: BaseWallet) => {
-        const isInstalled = !(
-          wm.getChainWalletState(wallet.info.name, chainName)?.walletState ===
-          WalletState.NotExist
-        );
+        const isInstalled =
+          wm.getChainWalletState(wallet.info.name, chainName)?.walletState !==
+          WalletState.NotExist;
 
         const iconSrc =
           typeof wallet.info.logo === "string"

--- a/src/components/Modal/ConnectWalletModal/index.tsx
+++ b/src/components/Modal/ConnectWalletModal/index.tsx
@@ -110,8 +110,9 @@ function ConnectWalletModal(props: ReactModal.Props) {
           !UNSUPPORT_WALLET_LIST[chainName].includes(wallet.info.name),
       )
       .map((wallet: BaseWallet) => {
-        const isInstalled = !!(
-          wallet.info.windowKey && wallet.info.windowKey in window
+        const isInstalled = !(
+          wm.getChainWalletState(wallet.info.name, chainName)?.walletState ===
+          WalletState.NotExist
         );
 
         const iconSrc =
@@ -133,12 +134,6 @@ function ConnectWalletModal(props: ReactModal.Props) {
               }
 
               await wm.connect(wallet.info.name, chainName);
-              if (
-                wm.getChainWalletState(wallet.info.name, chainName)
-                  ?.walletState !== WalletState.Connected
-              ) {
-                // TODO: open unsupported wallet modal
-              }
 
               if (props.onRequestClose) {
                 props.onRequestClose(event);


### PR DESCRIPTION
<!-- Optional  -->

## Background
The purpose of windowKey is different
Unable to know connection information of cosmostation's wallet

## Description
Currently, wallet.walletState is not set properly, so it is used as a temporary query.

## Checklist

- [ ] Keplr, Cosmostation installed
