### PR TITLE
feat: add chain select ui

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -256,6 +256,7 @@ function Modal({
       {...modalProps}
     >
       <Container
+        onClick={(e) => e.stopPropagation()}
         css={css`
           width: 100%;
           display: block;

--- a/src/components/SelectAssetForm/AssetItem.tsx
+++ b/src/components/SelectAssetForm/AssetItem.tsx
@@ -87,7 +87,7 @@ const Wrapper = styled.div<WrapperProps>`
 interface AssetIconProps {
   src?: string;
 }
-const AssetIcon = styled.div<AssetIconProps>`
+export const AssetIcon = styled.div<AssetIconProps>`
   width: 32px;
   height: 32px;
   min-width: 32px;

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -17,6 +17,16 @@ export const LARGE_BROWSER_SCREEN_CLASS: ScreenClass = "lg";
 
 export const DEFAULT_GUTTER_WIDTH = 32;
 
+export const GRID_MAX_WIDTH = {
+  xs: "unset",
+  sm: "940px",
+  md: "1180px",
+  lg: "1300px",
+  xl: "1300px",
+  xxl: "1300px",
+  xxxl: "1300px",
+};
+
 export const gridConfiguration: Configuration = {
   // Available: (xs), sm, md, lg
   // Disabled: xl, xxl, xxxl

--- a/src/layout/Main/ChainModal.tsx
+++ b/src/layout/Main/ChainModal.tsx
@@ -13,6 +13,16 @@ import { useScreenClass } from "react-grid-system";
 import ReactModal from "react-modal";
 import { useSearchParams } from "react-router-dom";
 
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  inset: 0;
+  z-index: 5000;
+`;
+
 const ChainsWrapper = styled.button`
   width: 100%;
   background: none;
@@ -46,65 +56,67 @@ function ChainModal(modalProps: ReactModal.Props) {
   const isTestnet = useMemo(() => chainName !== "xpla", [chainName]);
   const [searchParams, setSearchParams] = useSearchParams();
 
-  return (
-    <Modal
-      {...modalProps}
-      title="Select a network"
-      hasCloseButton
-      drawer={screenClass === MOBILE_SCREEN_CLASS}
-      overlay={screenClass === MOBILE_SCREEN_CLASS}
-      noPadding
-      style={
-        screenClass === MOBILE_SCREEN_CLASS
-          ? {}
-          : {
-              overlay: {
-                position: "absolute",
-                width: `calc(100% - ${DEFAULT_GUTTER_WIDTH}px)`,
-                maxWidth: `${GRID_MAX_WIDTH[screenClass]}`,
-                margin: "0 auto",
-                alignItems: "start",
-                justifyContent: "end",
-              },
-              content: {
-                marginTop: isTestnet ? "135px" : "105px",
-                marginRight: "116px",
-                top: "0",
-                width: "372px",
-              },
-              panel: {
-                maxHeight: "unset",
-                overflowY: "visible",
-                overflow: "hidden",
-              },
-            }
-      }
-    >
-      {DefaultChain.map((chain) => (
-        <ChainsWrapper
-          onClick={() => {
-            const newParams = new URLSearchParams(searchParams);
-            newParams.set(CHAIN_NAME_SEARCH_PARAM, chain.chainName);
-            setSearchParams(newParams);
-          }}
-          type="button"
-        >
-          <AssetIcon
-            asset={{
-              icon: chain.logoURIs?.svg ?? chain.logoURIs?.png,
+  return modalProps.isOpen ? (
+    <Overlay onClick={modalProps.onRequestClose}>
+      <Modal
+        {...modalProps}
+        title="Select a network"
+        hasCloseButton
+        drawer={screenClass === MOBILE_SCREEN_CLASS}
+        overlay={screenClass === MOBILE_SCREEN_CLASS}
+        noPadding
+        style={
+          screenClass === MOBILE_SCREEN_CLASS
+            ? {}
+            : {
+                overlay: {
+                  position: "absolute",
+                  width: `calc(100% - ${DEFAULT_GUTTER_WIDTH}px)`,
+                  maxWidth: `${GRID_MAX_WIDTH[screenClass]}`,
+                  margin: "0 auto",
+                  alignItems: "start",
+                  justifyContent: "end",
+                },
+                content: {
+                  marginTop: isTestnet ? "135px" : "105px",
+                  marginRight: "116px",
+                  top: "0",
+                  width: "372px",
+                },
+                panel: {
+                  maxHeight: "unset",
+                  overflowY: "visible",
+                  overflow: "hidden",
+                },
+              }
+        }
+      >
+        {DefaultChain.map((chain) => (
+          <ChainsWrapper
+            onClick={(e) => {
+              const newParams = new URLSearchParams(searchParams);
+              newParams.set(CHAIN_NAME_SEARCH_PARAM, chain.chainName);
+              setSearchParams(newParams);
             }}
-          />
-          {
-            /* 
+            type="button"
+          >
+            <AssetIcon
+              asset={{
+                icon: chain.logoURIs?.svg ?? chain.logoURIs?.png,
+              }}
+            />
+            {
+              /* 
             TODO: it will be updated https://github.com/cosmos/chain-registry/pull/6266
               {chain.prettyName}
               */
-            chain.chainName === "xpla" ? "XPLA" : "XPLA Testnet"
-          }
-        </ChainsWrapper>
-      ))}
-    </Modal>
-  );
+              chain.chainName === "xpla" ? "XPLA" : "XPLA Testnet"
+            }
+          </ChainsWrapper>
+        ))}
+      </Modal>
+    </Overlay>
+  ) : null;
 }
 
 export default ChainModal;

--- a/src/layout/Main/ChainModal.tsx
+++ b/src/layout/Main/ChainModal.tsx
@@ -2,7 +2,11 @@ import styled from "@emotion/styled";
 import AssetIcon from "components/AssetIcon";
 import Modal from "components/Modal";
 import { CHAIN_NAME_SEARCH_PARAM, DefaultChain } from "constants/dezswap";
-import { GRID_MAX_WIDTH, MOBILE_SCREEN_CLASS } from "constants/layout";
+import {
+  DEFAULT_GUTTER_WIDTH,
+  GRID_MAX_WIDTH,
+  MOBILE_SCREEN_CLASS,
+} from "constants/layout";
 import useNetwork from "hooks/useNetwork";
 import { useMemo } from "react";
 import { useScreenClass } from "react-grid-system";
@@ -56,7 +60,7 @@ function ChainModal(modalProps: ReactModal.Props) {
           : {
               overlay: {
                 position: "absolute",
-                width: "calc(100% - 32px)",
+                width: `calc(100% - ${DEFAULT_GUTTER_WIDTH}px)`,
                 maxWidth: `${GRID_MAX_WIDTH[screenClass]}`,
                 margin: "0 auto",
                 alignItems: "start",

--- a/src/layout/Main/ChainModal.tsx
+++ b/src/layout/Main/ChainModal.tsx
@@ -1,0 +1,106 @@
+import styled from "@emotion/styled";
+import AssetIcon from "components/AssetIcon";
+import Modal from "components/Modal";
+import { CHAIN_NAME_SEARCH_PARAM, DefaultChain } from "constants/dezswap";
+import { GRID_MAX_WIDTH, MOBILE_SCREEN_CLASS } from "constants/layout";
+import useNetwork from "hooks/useNetwork";
+import { useMemo } from "react";
+import { useScreenClass } from "react-grid-system";
+import ReactModal from "react-modal";
+import { useSearchParams } from "react-router-dom";
+
+const ChainsWrapper = styled.button`
+  width: 100%;
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  padding: 16px 13px;
+  gap: 6px;
+  font-size: 16px;
+  font-weight: 700;
+  &:first-of-type {
+    position: relative;
+    &::after {
+      content: "";
+      position: absolute;
+      left: 13px;
+      right: 13px;
+      top: 0;
+      display: block;
+      height: 1px;
+      background-color: ${({ theme }) => theme.colors.primary};
+    }
+  }
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.text.background};
+  }
+`;
+function ChainModal(modalProps: ReactModal.Props) {
+  const screenClass = useScreenClass();
+  const { chainName } = useNetwork();
+  const isTestnet = useMemo(() => chainName !== "xpla", [chainName]);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return (
+    <Modal
+      {...modalProps}
+      title="Select a network"
+      hasCloseButton
+      drawer={screenClass === MOBILE_SCREEN_CLASS}
+      overlay={screenClass === MOBILE_SCREEN_CLASS}
+      noPadding
+      style={
+        screenClass === MOBILE_SCREEN_CLASS
+          ? {}
+          : {
+              overlay: {
+                position: "absolute",
+                width: "calc(100% - 32px)",
+                maxWidth: `${GRID_MAX_WIDTH[screenClass]}`,
+                margin: "0 auto",
+                alignItems: "start",
+                justifyContent: "end",
+              },
+              content: {
+                marginTop: isTestnet ? "135px" : "105px",
+                marginRight: "116px",
+                top: "0",
+                width: "372px",
+              },
+              panel: {
+                maxHeight: "unset",
+                overflowY: "visible",
+                overflow: "hidden",
+              },
+            }
+      }
+    >
+      {DefaultChain.map((chain) => (
+        <ChainsWrapper
+          onClick={() => {
+            const newParams = new URLSearchParams(searchParams);
+            newParams.set(CHAIN_NAME_SEARCH_PARAM, chain.chainName);
+            setSearchParams(newParams);
+          }}
+          type="button"
+        >
+          <AssetIcon
+            asset={{
+              icon: chain.logoURIs?.svg ?? chain.logoURIs?.png,
+            }}
+          />
+          {
+            /* 
+            TODO: it will be updated https://github.com/cosmos/chain-registry/pull/6266
+              {chain.prettyName}
+              */
+            chain.chainName === "xpla" ? "XPLA" : "XPLA Testnet"
+          }
+        </ChainsWrapper>
+      ))}
+    </Modal>
+  );
+}
+
+export default ChainModal;

--- a/src/layout/Main/Header.tsx
+++ b/src/layout/Main/Header.tsx
@@ -490,7 +490,8 @@ function Header() {
                       TODO: it will be updated https://github.com/cosmos/chain-registry/pull/6266
                       {prettyName}
                        */
-                        chainName === "xpla" ? "XPLA" : "XPLA Testnet"
+                        screenClass !== MOBILE_SCREEN_CLASS &&
+                          (chainName === "xpla" ? "XPLA" : "XPLA Testnet")
                       }
                     </ChainButton>
                   </Col>

--- a/src/layout/Main/Header.tsx
+++ b/src/layout/Main/Header.tsx
@@ -53,6 +53,7 @@ import useNotifications from "hooks/useNotifications";
 import useConnectedWallet from "hooks/useConnectedWallet";
 import { useChain } from "hooks/useChain";
 import NotificationModal from "./NotificationModal";
+import ChainModal from "./ChainModal";
 
 export const DEFAULT_HEADER_HEIGHT = 150;
 export const SCROLLED_HEADER_HEIGHT = 77;
@@ -118,6 +119,20 @@ const Wrapper = styled.header<WrapperProps>`
       padding-top: 10px;
       padding-bottom: 10px;
     }
+  }
+`;
+
+const ChainButton = styled(Button)`
+  background-color: ${({ theme }) => theme.colors.text.background};
+  display: flex;
+  gap: 4px;
+  border: 0;
+  padding: 10px;
+  position: relative;
+
+  img {
+    height: 19px;
+    width: 19px;
   }
 `;
 
@@ -292,11 +307,12 @@ function Header() {
   const xplaBalance = useBalance(XPLA_ADDRESS);
   const walletPopover = useModal();
   const notificationModal = useHashModal("notifications");
+  const chainModal = useHashModal("chains");
   const { hasUnread: hasUnreadNotifications } = useNotifications();
   const theme = useTheme();
   const {
     chainName,
-    selectedChain: { explorers, chainId },
+    selectedChain: { explorers, chainId, logoURIs, prettyName },
   } = useNetwork();
   const connectWalletModal = useConnectWalletModal();
   const isTestnet = useMemo(() => chainName !== "xpla", [chainName]);
@@ -465,6 +481,18 @@ function Header() {
                             }
                       }
                     />
+                  </Col>
+                  <Col width="auto">
+                    <ChainButton onClick={() => chainModal.open()}>
+                      <img src={logoURIs.png} alt={prettyName} />
+                      {
+                        /* 
+                      TODO: it will be updated https://github.com/cosmos/chain-registry/pull/6266
+                      {prettyName}
+                       */
+                        chainName === "xpla" ? "XPLA" : "XPLA Testnet"
+                      }
+                    </ChainButton>
                   </Col>
                   <Col width="auto">
                     {/* // TODO: Refactor */}
@@ -734,6 +762,10 @@ function Header() {
       <NotificationModal
         isOpen={notificationModal.isOpen}
         onRequestClose={() => notificationModal.close()}
+      />
+      <ChainModal
+        isOpen={chainModal.isOpen}
+        onRequestClose={() => chainModal.open(false)}
       />
     </>
   );


### PR DESCRIPTION
## Description
Add the chain selector UI to allow users to easily switch between different networks.
This PR implements a new chain selection interface that enhances the wallet connection experience by providing a clean and intuitive way to switch between supported chains.

## Checklist

- [ ]  Can change the chain using the chain selector
- [ ]  UI correctly displays the currently selected chain
- [ ]  Tested across desktop and mobile viewports
