### PR TITLE
fix: unvisible chain name on mobile view

### DIFF
--- a/src/layout/Main/Header.tsx
+++ b/src/layout/Main/Header.tsx
@@ -485,7 +485,7 @@ function Header() {
                   <Col width="auto">
                     <ChainButton onClick={() => chainModal.open()}>
                       <img src={logoURIs.png} alt={prettyName} />
-                      {prettyName}
+                      {screenClass !== MOBILE_SCREEN_CLASS && prettyName}
                     </ChainButton>
                   </Col>
                   <Col width="auto">


### PR DESCRIPTION

## Description
https://github.com/dezswap/dezswap-web-app/commit/ff1bab262eed5fe365ca14ab36a53b37bc740f1e
I fixed it again because that PR removed the viewport condition.

## Checklist
- [ ]   Selected chain name is properly hidden in mobile view
