### PR TITLE
feat: add playAnalytics page

### DIFF
--- a/src/pages/PlayAnalytics/index.tsx
+++ b/src/pages/PlayAnalytics/index.tsx
@@ -1,0 +1,83 @@
+import { Col, Container, Row } from "react-grid-system";
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import Hr from "components/Hr";
+import ScrollToTop from "components/ScrollToTop";
+import Typography from "components/Typography";
+import useDashboardTokenDetail from "hooks/dashboard/useDashboardTokenDetail";
+import Chart from "pages/Tokens/TokenDetail/Chart";
+import TokenSummary from "pages/Tokens/TokenDetail/TokenSummary";
+import TokenTransactions from "pages/Tokens/TokenDetail/TokenTransactions";
+import { useParams, Outlet } from "react-router-dom";
+
+const Wrapper = styled(Container)`
+  width: 100%;
+  height: auto;
+  position: relative;
+  display: flex;
+`;
+
+function PlayAnalytics() {
+  const { tokenAddress } = useParams<{ tokenAddress: string }>();
+
+  const dashboardToken = useDashboardTokenDetail(tokenAddress || "");
+
+  return (
+    <Wrapper key={tokenAddress}>
+      <ScrollToTop />
+      <Container style={{ padding: "20px 0" }}>
+        {dashboardToken === null ? (
+          <Typography
+            color="primary"
+            size={32}
+            weight={900}
+            css={css`
+              margin-bottom: 19px;
+            `}
+          >
+            Invalid token...
+          </Typography>
+        ) : (
+          <>
+            <Row
+              justify="between"
+              align="start"
+              gutterWidth={14}
+              css={css`
+                row-gap: 13px;
+                margin-bottom: 50px;
+              `}
+            >
+              <Col xs={12} md={7}>
+                {tokenAddress && <Chart tokenAddress={tokenAddress} />}
+              </Col>
+              <Col xs={12} md={5}>
+                {tokenAddress && <TokenSummary tokenAddress={tokenAddress} />}
+              </Col>
+            </Row>
+
+            <Typography
+              color="primary"
+              size={32}
+              weight={900}
+              css={css`
+                margin-bottom: 19px;
+              `}
+            >
+              Transactions
+            </Typography>
+            <Hr
+              css={css`
+                margin-bottom: 20px;
+              `}
+            />
+            {tokenAddress && <TokenTransactions tokenAddress={tokenAddress} />}
+          </>
+        )}
+      </Container>
+      <Outlet />
+    </Wrapper>
+  );
+}
+
+export default PlayAnalytics;

--- a/src/pages/PlayAnalytics/index.tsx
+++ b/src/pages/PlayAnalytics/index.tsx
@@ -26,18 +26,7 @@ function PlayAnalytics() {
     <Wrapper key={tokenAddress}>
       <ScrollToTop />
       <Container style={{ padding: "20px 0" }}>
-        {dashboardToken === null ? (
-          <Typography
-            color="primary"
-            size={32}
-            weight={900}
-            css={css`
-              margin-bottom: 19px;
-            `}
-          >
-            Invalid token...
-          </Typography>
-        ) : (
+        {dashboardToken !== null && (
           <>
             <Row
               justify="between"

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ import MainLayout from "layout/Main";
 import withDisclaimerAgreement from "hocs/withDisclaimerAgreement";
 import SwapPageAsModal from "components/Modal/SwapModal";
 import Redirect from "components/Redirect";
+import PlayAnalytics from "pages/PlayAnalytics";
 // TODO: uncomment when lockdrop is ready
 // import LockdropPage from "pages/Earn/Lockdrop";
 // import StakePage from "pages/Earn/Lockdrop/Stake";
@@ -133,6 +134,7 @@ const routes = createBrowserRouter([
       { path: "*", element: <Error404 /> },
     ],
   },
+  { path: "/play3-analytics/:tokenAddress", element: <PlayAnalytics /> },
 ]);
 
 export default routes;


### PR DESCRIPTION
## Description

Add support for the Play3 iframe integration.
Related Slack discussion: https://delight-labs.slack.com/archives/C0442KWGS1J/p1747991350891479

Added a new route to render the Play3 iframe:
```
<iframe src={`https://app.dezswap.io//play3-analytics/${tokenAddress}?chainname=${chainName}`} />
```

## Checklist

- [ ] Verify that the iframe renders correctly
- [ ] Ensure the correct view is displayed based on tokenAddress and chainName
