### PR TITLE
feat: add option in chart tabs sort

### DIFF
--- a/src/pages/PlayAnalytics/index.tsx
+++ b/src/pages/PlayAnalytics/index.tsx
@@ -39,7 +39,7 @@ function PlayAnalytics() {
             >
               <Col xs={12} md={7}>
                 {tokenAddress && (
-                  <Chart tokenAddress={tokenAddress} isPriceFirst />
+                  <Chart tokenAddress={tokenAddress} defaultTabIndex={2} />
                 )}
               </Col>
               <Col xs={12} md={5}>

--- a/src/pages/PlayAnalytics/index.tsx
+++ b/src/pages/PlayAnalytics/index.tsx
@@ -38,7 +38,9 @@ function PlayAnalytics() {
               `}
             >
               <Col xs={12} md={7}>
-                {tokenAddress && <Chart tokenAddress={tokenAddress} />}
+                {tokenAddress && (
+                  <Chart tokenAddress={tokenAddress} isPriceFirst />
+                )}
               </Col>
               <Col xs={12} md={5}>
                 {tokenAddress && <TokenSummary tokenAddress={tokenAddress} />}

--- a/src/pages/Tokens/TokenDetail/Chart.tsx
+++ b/src/pages/Tokens/TokenDetail/Chart.tsx
@@ -19,7 +19,7 @@ import Modal from "components/Modal";
 import CurrencyFormatter from "components/utils/CurrencyFormatter";
 import useChartData from "./useChartData";
 
-const defaultChartTypeTabs = ["Volume", "TVL", "Price"].map((label) => ({
+const chartTypeTabs = ["Volume", "TVL", "Price"].map((label) => ({
   key: label,
   label,
   value: label.toLowerCase() as DashboardTokenChartType,
@@ -35,16 +35,13 @@ const chartDurationOptions = ["Month", "Quarter", "Year", "All"].map(
 
 function Chart({
   tokenAddress,
-  isPriceFirst = false,
+  defaultTabIndex = 0,
 }: {
   tokenAddress: string;
-  isPriceFirst?: boolean;
+  defaultTabIndex?: number;
 }) {
   const screenClass = useScreenClass();
-  const [selectedTabIndex, setSelectedTabIndex] = useState(0);
-  const chartTypeTabs = useMemo(() => {
-    return isPriceFirst ? defaultChartTypeTabs.reverse() : defaultChartTypeTabs;
-  }, [isPriceFirst]);
+  const [selectedTabIndex, setSelectedTabIndex] = useState(defaultTabIndex);
   const selectedTabValue = useMemo(() => {
     return chartTypeTabs[selectedTabIndex].value;
   }, [selectedTabIndex]);

--- a/src/pages/Tokens/TokenDetail/Chart.tsx
+++ b/src/pages/Tokens/TokenDetail/Chart.tsx
@@ -19,7 +19,7 @@ import Modal from "components/Modal";
 import CurrencyFormatter from "components/utils/CurrencyFormatter";
 import useChartData from "./useChartData";
 
-const chartTypeTabs = ["Volume", "TVL", "Price"].map((label) => ({
+const defaultChartTypeTabs = ["Volume", "TVL", "Price"].map((label) => ({
   key: label,
   label,
   value: label.toLowerCase() as DashboardTokenChartType,
@@ -33,9 +33,18 @@ const chartDurationOptions = ["Month", "Quarter", "Year", "All"].map(
   }),
 );
 
-function Chart({ tokenAddress }: { tokenAddress: string }) {
+function Chart({
+  tokenAddress,
+  isPriceFirst = false,
+}: {
+  tokenAddress: string;
+  isPriceFirst?: boolean;
+}) {
   const screenClass = useScreenClass();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
+  const chartTypeTabs = useMemo(() => {
+    return isPriceFirst ? defaultChartTypeTabs.reverse() : defaultChartTypeTabs;
+  }, [isPriceFirst]);
   const selectedTabValue = useMemo(() => {
     return chartTypeTabs[selectedTabIndex].value;
   }, [selectedTabIndex]);


### PR DESCRIPTION

## Description

Default to Price tab in Play3 Analytics.

To support this, added an isPriceFirst prop to the Chart component.
When isPriceFirst is true, the Price tab will be shown as the default selected tab.

[Related Slack discussion](https://delight-labs.slack.com/archives/C08RN7DL6BV/p1748429891105329?thread_ts=1747988389.106229&cid=C08RN7DL6BV)

 ## Checklist

- [ ] Verified that Price tab is shown by default on Play3 Analytics page
