### PR TITLE
fix: ensure clearing queryClient on channame change

### DIFF
--- a/src/layout/Main/index.tsx
+++ b/src/layout/Main/index.tsx
@@ -157,7 +157,12 @@ function MainLayout({ children }: PropsWithChildren) {
   // but it's better to keep it just in case we don't reload on network change in the future
   const queryClient = useQueryClient();
   useEffect(
-    () => chainNameStore.subscribe(() => queryClient.clear()),
+    () =>
+      chainNameStore.subscribe((state, prevState) => {
+        if (state.chainName !== prevState.chainName) {
+          queryClient.clear();
+        }
+      }),
     [queryClient],
   );
 


### PR DESCRIPTION
<!-- Optional  -->

## Background

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Current clear login fires even though setter calls without any changes.

## Description

<!--- Describe your changes in detail -->
<!--- Add subsections (e.g. Screenshot, Note) if needed -->

make it sure that queryClient.clear() is called when channame changes


