### PR TITLE
fix: apply slash surrogate to IBC addresses in API paths

### DIFF
--- a/src/api/custom-instance.ts
+++ b/src/api/custom-instance.ts
@@ -6,9 +6,19 @@ import { chainNameStore } from "~/stores/chainName";
 
 const instance = Axios.create();
 
+/**
+ * Replace encoded slashes in a URL with a surrogate form the API restores
+ * server-side. GCP load balancer rejects paths containing `%2F`, and currently
+ * only IBC denoms (`ibc/XXX`) carry slashes through path segments.
+ *
+ * See https://github.com/dezswap/dezswap-api/pull/93.
+ */
+const applySlashSurrogate = (url?: string) => url?.replace(/ibc%2F/g, "ibc-");
+
 instance.interceptors.request.use((config) => {
   config.baseURL = getBaseUrl();
   config.params = { [Date.now()]: "", ...config.params };
+  config.url = applySlashSurrogate(config.url);
   return config;
 });
 


### PR DESCRIPTION
<!-- Optional  -->

## Background

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to 
- https://github.com/dezswap/dezswap-api/pull/93
- https://delight-labs.slack.com/archives/C0442KWGS1J/p1776663297683149

## Description

<!--- Describe your changes in detail -->
<!--- Add subsections (e.g. Screenshot, Note) if needed -->



### Before

<img width="1476" height="380" alt="image" src="https://github.com/user-attachments/assets/4a1a88f3-01e0-487d-8ae3-9f8db4344881" />


### After

<img width="1142" height="321" alt="image" src="https://github.com/user-attachments/assets/51f8612b-8f7c-4054-862b-fc8ea36e380d" />


## Checklist

- [ ] Item
