### PR TITLE
fix: apply axlUSDC fixed-price mock to price chart only

### DIFF
--- a/src/pages/Tokens/TokenDetail/useChartData.ts
+++ b/src/pages/Tokens/TokenDetail/useChartData.ts
@@ -13,7 +13,7 @@ type ChartAPIParameters = Parameters<
   typeof useGetDashboardChartTokensAddressType
 >;
 
-const getAxlUSDCChartData = (
+const getAxlUSDCPriceChartData = (
   duration: GetDashboardChartTokensAddressTypeDuration | "all" = "month",
 ): Awaited<ReturnType<typeof getDashboardChartTokensAddressType>> => {
   const days = {
@@ -45,15 +45,19 @@ export const useChartData = (
 
   const { assetInfos } = useAssets();
 
-  const isAxlUSDC = useMemo(() => {
+  const isAxlUSDCPrice = useMemo(() => {
     const asset = assetInfos[address];
-    return !!(asset?.verified && asset.symbol === "axlUSDC");
-  }, [assetInfos, address]);
+    return !!(
+      asset?.verified &&
+      asset.symbol === "axlUSDC" &&
+      type === "price"
+    );
+  }, [assetInfos, address, type]);
 
-  const axlUSDCQuery = useQuery({
-    queryKey: ["axlUSDCChartData", duration],
-    queryFn: () => getAxlUSDCChartData(duration),
-    enabled: isAxlUSDC,
+  const axlUSDCPriceQuery = useQuery({
+    queryKey: ["axlUSDCPriceChartData", duration],
+    queryFn: () => getAxlUSDCPriceChartData(duration),
+    enabled: isAxlUSDCPrice,
   });
 
   const dashboardQuery = useGetDashboardChartTokensAddressType(
@@ -61,11 +65,11 @@ export const useChartData = (
     type,
     // @ts-expect-error "all" is valid value but not included in the spec
     { duration },
-    { query: { enabled: !isAxlUSDC } },
+    { query: { enabled: !isAxlUSDCPrice } },
   );
 
   return {
-    ...(isAxlUSDC ? axlUSDCQuery : dashboardQuery),
+    ...(isAxlUSDCPrice ? axlUSDCPriceQuery : dashboardQuery),
     type,
     duration,
     setDuration,


### PR DESCRIPTION
<!-- Optional  -->

## Background

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Token Detail page renders incorrect Volume, TVL charts for axlUSDC. Both are pinned to a constant value, so the cumulative total is shown incorrectly.

## Description

<!--- Describe your changes in detail -->
<!--- Add subsections (e.g. Screenshot, Note) if needed -->

axlUSDC is a price-pegged stablecoin, so only its price should be fixed at $1. 
The fix narrows the condition to price only, so the other chart types (volume, tvl) can use real API data.

## Checklist

### Before 

<img width="817" height="627" alt="image" src="https://github.com/user-attachments/assets/a3fe4443-fa5d-4857-bbb0-8d0d108e5411" />

<img width="803" height="623" alt="image" src="https://github.com/user-attachments/assets/f96380ef-1338-46b8-8405-8a65edb48974" />


### After

<img width="779" height="643" alt="image" src="https://github.com/user-attachments/assets/9ffa0c0d-6012-4c80-8672-e704fe060771" />

<img width="788" height="604" alt="image" src="https://github.com/user-attachments/assets/48c97c95-9cfa-403f-84d7-810d64cb1eb4" />
